### PR TITLE
prevent error if TrustAllCertsPolicy already defined

### DIFF
--- a/GlobalDashboardPS/Private/Invoke-OVGDRequest.ps1
+++ b/GlobalDashboardPS/Private/Invoke-OVGDRequest.ps1
@@ -17,7 +17,14 @@ function Invoke-OVGDRequest {
     )
 
     BEGIN {
-        if($IgnoreSSL){
+        $SkipCertCheckParam = @{}
+        
+        if ($IgnoreSSL -and $PSVersionTable.PSEdition -eq 'Core'){
+            $SkipCertCheckParam = @{
+                'SkipCertificateCheck' = $true
+            }
+        }
+        elseif ($IgnoreSSL){
             Set-InsecureSSL
         }
     }
@@ -43,7 +50,7 @@ function Invoke-OVGDRequest {
         }
 
         Write-Verbose "$Method URI: $($uribuilder.uri)"
-        $response = Invoke-RestMethod -Method $Method -Uri $URIBuilder.Uri -Headers $headers -Body $Body -ContentType $ContentType -ErrorVariable apiErr
+        $response = Invoke-RestMethod -Method $Method -Uri $URIBuilder.Uri -Headers $headers -Body $Body -ContentType $ContentType -ErrorVariable apiErr @SkipCertCheckParam
 
     }
     END {

--- a/GlobalDashboardPS/Private/Set-InsecureSSL.ps1
+++ b/GlobalDashboardPS/Private/Set-InsecureSSL.ps1
@@ -2,7 +2,9 @@ function Set-InsecureSSL {
     [cmdletbinding(SupportsShouldProcess)]
     param()
 
-add-type @"
+    if (-not ("TrustAllCertsPolicy" -as [type])) {
+
+Add-Type @"
     using System.Net;
     using System.Security.Cryptography.X509Certificates;
     public class TrustAllCertsPolicy : ICertificatePolicy {
@@ -13,6 +15,7 @@ add-type @"
         }
     }
 "@
+    }
 
     if($PSCmdlet.ShouldProcess("ShouldProcess?")){
         [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy


### PR DESCRIPTION
prevent this error if TrustAllCertsPolicy is already set

add-type : Cannot add type. The type name 'TrustAllCertsPolicy' already exists.
At C:\Program Files\WindowsPowerShell\Modules\GlobalDashboardPS\0.9.1\Private\Set-InsecureSSL.ps1:5 char:1